### PR TITLE
Upgrade UBI9 image version from 9.3-1610 to 9.4-1123.1719560047

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Global Args #################################################################
-ARG BASE_UBI_IMAGE_TAG=9.4-1123.1719560047
+ARG BASE_UBI_IMAGE_TAG=9.4
 ARG PROTOC_VERSION=25.3
 ARG PYTORCH_INDEX="https://download.pytorch.org/whl"
 # ARG PYTORCH_INDEX="https://download.pytorch.org/whl/nightly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Global Args #################################################################
-ARG BASE_UBI_IMAGE_TAG=9.3-1610
+ARG BASE_UBI_IMAGE_TAG=9.4-1123.1719560047
 ARG PROTOC_VERSION=25.3
 ARG PYTORCH_INDEX="https://download.pytorch.org/whl"
 # ARG PYTORCH_INDEX="https://download.pytorch.org/whl/nightly"


### PR DESCRIPTION
#### Motivation
Jira : https://issues.redhat.com/browse/RHOAIENG-10001
IBM has requested for new build of text-generation-inference from RHOAI-2.8 branch to incorporate vulnerability fix came with latest UBI image. Current latest available release of UBI 9 image is 9.4-1123.1719560047. I had raised this PR to upgrade UBI 9 image version from 9.3-1610 to 9.4-1123.1719560047.

#### Modifications

[Describe the code changes]

#### Result

[Describe how the changes affects existing behavior and how to test it]

#### Related Issues

[Resolves #123]
