### PR TITLE
downgrade click to resolve issues with caikit-tgis-serving image on 2.22

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -15,6 +15,7 @@ grpcio = "^1.62.2"
 grpcio-reflection = "^1.62.2"
 loguru = "^0.7.2"
 typer = "^0.12.3"
+click = ">=8.0,<8.1.8"
 accelerate = { version = "0.27.2", optional = true }
 bitsandbytes = { version = "^0.42.0", optional = true }
 scipy = "^1.11.4"


### PR DESCRIPTION

#### Motivation
Jira:  https://issues.redhat.com/browse/RHOAIENG-39607
[Describe why this change is needed]

text-generation-server was picking up the newest Click releases through Typer, and Click ≥8.2 rejects Typer’s “secondary flag” usage. Shards in quay.io/modh/text-generation-inference then crash at startup (TypeError: Secondary flag is not valid for non-boolean flag.). Pinning Click below the breaking release is required to keep the launcher working.

#### Modifications

Added an explicit click = ">=8.0,<8.1.8" dependency in text-generation-inference/server/pyproject.toml alongside the existing Typer pin so Poetry resolves the safe version instead of the latest.

[Describe the code changes]
