### PR TITLE
resolve caikit-tgis-serving build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ARG AUTO_GPTQ_VERSION=0.7.1
 # e.g. flash-attn v2.5.2 => torch ['1.12.1', '1.13.1', '2.0.1', '2.1.2', '2.2.0', '2.3.0.dev20240126']
 # https://github.com/Dao-AILab/flash-attention/blob/v2.5.2/.github/workflows/publish.yml#L47
 # use nightly build index for torch .dev pre-release versions
-ARG PYTORCH_VERSION=2.2.1
+ARG PYTORCH_VERSION=2.6.0
+ARG PYTORCH_CUDA_CHANNEL=cu126
 
 ARG PYTHON_VERSION=3.11
 
@@ -87,7 +88,7 @@ ENV LIBRARY_PATH="$CUDA_HOME/lib64/stubs"
 
 ## Rust builder ################################################################
 # Using bookworm for compilation so the rust binaries get linked against libssl.so.3
-FROM rust:1.78-bookworm as rust-builder
+FROM rust:1.82-bookworm as rust-builder
 ARG PROTOC_VERSION
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
@@ -182,6 +183,7 @@ RUN cd integration_tests && make install
 FROM cuda-devel as python-builder
 ARG PYTORCH_INDEX
 ARG PYTORCH_VERSION
+ARG PYTORCH_CUDA_CHANNEL
 ARG PYTHON_VERSION
 ARG MINIFORGE_VERSION=23.11.0-0
 
@@ -203,7 +205,7 @@ ENV PATH=/opt/tgis/bin/:$PATH
 # Install specific version of torch
 RUN pip install ninja==1.11.1.1 --no-cache-dir
 RUN pip install packaging --no-cache-dir
-RUN pip install torch==$PYTORCH_VERSION+cu121 --index-url "${PYTORCH_INDEX}/cu121" --no-cache-dir
+RUN pip install torch==${PYTORCH_VERSION}+${PYTORCH_CUDA_CHANNEL} --index-url "${PYTORCH_INDEX}/${PYTORCH_CUDA_CHANNEL}" --no-cache-dir
 
 
 ## Build flash attention v2 ####################################################

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.82.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
#### Motivation
Jira: https://issues.redhat.com/browse/RHOAIENG-39607

[Describe why this change is needed]
Resolve build issues --> https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhoai-tenant/applications/external-rhoai-v2-22/pipelineruns/text-generation-inference-v2-22-on-push-kljb8
#### Modifications

Tekton build kept failing because the Rust toolchain inside the Dockerfile image was too old

[Describe the code changes]

 Bumped rust-toolchain.toml and the rust:builder stage to rustc 1.82 so router/launcher compile, updated PYTORCH_VERSION to 2.6.0 and introduced PYTORCH_CUDA_CHANNEL (default cu126) so the CUDA install pulls a matching wheel, plus kept the rest of the Dockerfile in sync.
#### Result

[Describe how the changes affects existing behavior and how to test it]
Builds now run with rustc 1.82 and install torch 2.6.0 + cu126, eliminating the earlier cargo failures and CVEs
